### PR TITLE
refactor: update file upload logic to use UUID for storage

### DIFF
--- a/backend/application/dashboard/file/uploadFile/usecase.go
+++ b/backend/application/dashboard/file/uploadFile/usecase.go
@@ -32,10 +32,6 @@ func (uc *UseCase) Execute(request *Request) (*Response, error) {
 		}, nil
 	}
 
-	if err := uc.storage.Store(context.Background(), request.Name, request.FileReader, request.Size); err != nil {
-		return nil, err
-	}
-
 	uuid, err := uc.filesRepository.Save(&file.File{
 		Name:      request.Name,
 		Size:      request.Size,
@@ -43,6 +39,12 @@ func (uc *UseCase) Execute(request *Request) (*Response, error) {
 		MimeType:  request.MimeType,
 	})
 	if err != nil {
+		return nil, err
+	}
+
+	if err := uc.storage.Store(context.Background(), uuid, request.FileReader, request.Size); err != nil {
+		_ = uc.filesRepository.Delete(uuid)
+
 		return nil, err
 	}
 

--- a/backend/application/dashboard/file/uploadFile/usecase_test.go
+++ b/backend/application/dashboard/file/uploadFile/usecase_test.go
@@ -59,6 +59,8 @@ func TestUseCase_Execute(t *testing.T) {
 
 		response, err := NewUseCase(&filesRepository, &storage, &validator).Execute(&r)
 
+		filesRepository.AssertNotCalled(t, "Delete")
+
 		assert.NoError(t, err)
 		assert.Equal(t, &expectedResponse, response)
 	})
@@ -89,6 +91,7 @@ func TestUseCase_Execute(t *testing.T) {
 
 		filesRepository.AssertNotCalled(t, "Save")
 		storage.AssertNotCalled(t, "Store")
+		filesRepository.AssertNotCalled(t, "Delete")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &expectedResponse, response)
@@ -175,6 +178,7 @@ func TestUseCase_Execute(t *testing.T) {
 		response, err := NewUseCase(&filesRepository, &storage, &validator).Execute(&r)
 
 		storage.AssertNotCalled(t, "Store")
+		filesRepository.AssertNotCalled(t, "Delete")
 
 		assert.ErrorIs(t, err, expectedErr)
 		assert.Nil(t, response)

--- a/backend/application/dashboard/file/uploadFile/usecase_test.go
+++ b/backend/application/dashboard/file/uploadFile/usecase_test.go
@@ -51,11 +51,11 @@ func TestUseCase_Execute(t *testing.T) {
 		validator.On("Validate", &r).Once().Return(nil)
 		defer validator.AssertExpectations(t)
 
-		storage.On("Store", context.Background(), r.Name, r.FileReader, r.Size).Once().Return(nil)
-		defer storage.AssertExpectations(t)
-
 		filesRepository.On("Save", &f).Once().Return(fileUUID, nil)
 		defer filesRepository.AssertExpectations(t)
+
+		storage.On("Store", context.Background(), fileUUID, r.FileReader, r.Size).Once().Return(nil)
+		defer storage.AssertExpectations(t)
 
 		response, err := NewUseCase(&filesRepository, &storage, &validator).Execute(&r)
 
@@ -87,8 +87,8 @@ func TestUseCase_Execute(t *testing.T) {
 
 		response, err := NewUseCase(&filesRepository, &storage, &validator).Execute(&r)
 
-		storage.AssertNotCalled(t, "Store")
 		filesRepository.AssertNotCalled(t, "Save")
+		storage.AssertNotCalled(t, "Store")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &expectedResponse, response)
@@ -111,18 +111,30 @@ func TestUseCase_Execute(t *testing.T) {
 				Size:       int64(len(fileContent)),
 			}
 
+			f = file.File{
+				Name:      r.Name,
+				Size:      r.Size,
+				OwnerUUID: r.OwnerUUID,
+			}
+
+			fileUUID = "test-file-uuid"
+
 			expectedErr = errors.New("storage error")
 		)
 
 		validator.On("Validate", &r).Once().Return(nil)
 		defer validator.AssertExpectations(t)
 
-		storage.On("Store", context.Background(), r.Name, r.FileReader, r.Size).Once().Return(expectedErr)
+		filesRepository.On("Save", &f).Once().Return(fileUUID, nil)
+		defer filesRepository.AssertExpectations(t)
+
+		storage.On("Store", context.Background(), fileUUID, r.FileReader, r.Size).Once().Return(expectedErr)
 		defer storage.AssertExpectations(t)
 
-		response, err := NewUseCase(&filesRepository, &storage, &validator).Execute(&r)
+		filesRepository.On("Delete", fileUUID).Once().Return(nil)
+		defer filesRepository.AssertExpectations(t)
 
-		filesRepository.AssertNotCalled(t, "Save")
+		response, err := NewUseCase(&filesRepository, &storage, &validator).Execute(&r)
 
 		assert.ErrorIs(t, err, expectedErr)
 		assert.Nil(t, response)
@@ -157,13 +169,12 @@ func TestUseCase_Execute(t *testing.T) {
 		validator.On("Validate", &r).Once().Return(nil)
 		defer validator.AssertExpectations(t)
 
-		storage.On("Store", context.Background(), r.Name, r.FileReader, r.Size).Once().Return(nil)
-		defer storage.AssertExpectations(t)
-
 		filesRepository.On("Save", &f).Once().Return("", expectedErr)
 		defer filesRepository.AssertExpectations(t)
 
 		response, err := NewUseCase(&filesRepository, &storage, &validator).Execute(&r)
+
+		storage.AssertNotCalled(t, "Store")
 
 		assert.ErrorIs(t, err, expectedErr)
 		assert.Nil(t, response)

--- a/backend/presentation/http/api/dashboard/file/upload_test.go
+++ b/backend/presentation/http/api/dashboard/file/upload_test.go
@@ -70,11 +70,11 @@ func TestUploadHandler(t *testing.T) {
 		requestValidator.On("Validate", mock.Anything).Once().Return(nil)
 		defer requestValidator.AssertExpectations(t)
 
-		storage.On("Store", context.Background(), r.Name, mock.Anything, r.Size).Once().Return(nil)
-		defer storage.AssertExpectations(t)
-
 		filesRepository.On("Save", &f).Once().Return(fileUUID, nil)
 		defer filesRepository.AssertExpectations(t)
+
+		storage.On("Store", context.Background(), fileUUID, mock.Anything, r.Size).Once().Return(nil)
+		defer storage.AssertExpectations(t)
 
 		handler := NewUploadHandler(createfile.NewUseCase(&filesRepository, &storage, &requestValidator), &authorizer)
 

--- a/backend/presentation/http/api/dashboard/file/upload_test.go
+++ b/backend/presentation/http/api/dashboard/file/upload_test.go
@@ -85,6 +85,8 @@ func TestUploadHandler(t *testing.T) {
 
 		handler.ServeHTTP(response, request)
 
+		filesRepository.AssertNotCalled(t, "Delete")
+
 		expectedBody, err := os.ReadFile("testdata/upload-files-response.json")
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Currently, uploading a file with the same name as the current file causes the current file to be overwritten. I solved this problem in this PR.
